### PR TITLE
Fix transposing of an empty collection

### DIFF
--- a/src/Collections/CollectionMacrosServiceProvider.php
+++ b/src/Collections/CollectionMacrosServiceProvider.php
@@ -52,6 +52,10 @@ class CollectionMacrosServiceProvider extends ServiceProvider
          * @see https://adamwathan.me/2016/04/06/cleaning-up-form-input-with-transpose/
          */
         Collection::macro('transpose', function () {
+            if ($this->isEmpty()) {
+                return $this;
+            }
+            
             $items = array_map(function (...$items) {
                 return $items;
             }, ...$this->values());
@@ -66,6 +70,10 @@ class CollectionMacrosServiceProvider extends ServiceProvider
          * parse more than one missing column.
          */
         Collection::macro('transposeWithKeys', function (array $rows = null) {
+            if ($this->isEmpty()) {
+                return $this;
+            }
+            
             $rows = $rows ?? $this->values()->reduce(function (array $rows, array $values) {
                     return array_unique(array_merge($rows, array_keys($values)));
                 }, []);

--- a/tests/Unit/Collections/CollectionMacrosTest.php
+++ b/tests/Unit/Collections/CollectionMacrosTest.php
@@ -207,6 +207,12 @@ class CollectionMacrosTest extends TestCase
             ])->transposeWithKeys()
         );
     }
+    
+    public function test it can transpose an empty collection()
+    {
+        $this->assertEquals(collect(), collect()->transpose());
+        $this->assertEquals(collect(), collect()->transposeWithKeys());
+    }
 
     /**
      * Get package providers.


### PR DESCRIPTION
Transposing methods of empty collection fail because array_map can't work without a second argument.
